### PR TITLE
Drop problematic dollar sign

### DIFF
--- a/src/main/g8/src/test/scala/http.scala
+++ b/src/main/g8/src/test/scala/http.scala
@@ -30,7 +30,7 @@ object Request:
         Thread.sleep(100)
         awaitOpen(port, retries - 1)
       } else {
-        throw new Exception(s"expected port $port to be open")
+        throw new Exception("port" + port + " should be open")
       }
     }
 


### PR DESCRIPTION
This was causing scripted to complain:

```
Falling back to file copy for
sbt-war.g8/src/main/g8/src/test/scala/http.scala: File:
sbt-war.g8/src/main/g8/src/test/scala/http.scala, An unexpected error
occurred while processing the template. Check that all
literal '$' are properly escaped with '\$'
```